### PR TITLE
Fix showing login page when refreshing HomePage.

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -12,7 +12,7 @@ export function useAuth() {
 }
 
 export function AuthProvider({ children }) {
-  const [auth, setAuth] = useState(false);
+  const [auth, setAuth] = useState(null);
 
   useEffect(() => {
     let checkAuth = async () => {

--- a/frontend/src/libs/auth/auth.js
+++ b/frontend/src/libs/auth/auth.js
@@ -3,6 +3,8 @@ import axios from "axios";
 import { Navigate, Outlet, redirect } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 
+import LinearProgress from "@mui/material/LinearProgress";
+
 const API_GET_CSRF_TOKEN = "/api/auth-get-csrf-token/";
 const API_CHECK_AUTH = "/api/auth-check/";
 
@@ -21,6 +23,16 @@ export async function loadCSRFToken() {
 
 export const PrivateRoutes = () => {
   const { auth } = useAuth();
+  // render loading page if authentication is not yet checked
+  if (auth === null) {
+    return (
+      <div className="flex justify-center items-center w-full h-full">
+        <div className="w-[30%] max-w-[300px]">
+          <LinearProgress />
+        </div>
+      </div>
+    );
+  }
   return auth ? <Outlet /> : <Navigate to="/account/login" />;
 };
 


### PR DESCRIPTION
* The problem is caused by CheckAuthentication. As the request is triggered when refreshing pages and authContext is by default to be false which cause a navigation to Login page.

* Fix the above problem by adding a loader screen that is rendered if authentication is not yet finished checking