### PR TITLE
Fix the major glitch of Milestone model

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -75,7 +75,7 @@ class Quote(models.Model):
 class Milestone(models.Model):
     user_id = models.ForeignKey(User, on_delete=models.CASCADE, null=False)
     plannedAt = models.DateField(
-        null=False, blank=False, default=date.today, unique=True)
+        null=False, blank=False, default=date.today)
     completed = models.BooleanField(default=False, null=False)
 
     def __str__(self):

--- a/api/views.py
+++ b/api/views.py
@@ -335,7 +335,11 @@ class UpdateReviewingRecordStatus(APIView):
             # complete milestone
             milestoneSet = Milestone.objects.filter(
                 user_id=request.user, plannedAt=date.today())
-            if milestoneSet.count() == 1:
+            if milestoneSet.count() == 0:
+                # in case review plan is directly added, not through generateReviewPlan API
+                milestone = Milestone.objects.create(
+                    user_id=request.user, completed=True)
+            elif milestoneSet.count() == 1:
                 milestone = milestoneSet[0]
                 milestone.completed = True
                 milestone.save()


### PR DESCRIPTION
* Fix incorrectly marking plannedAt of Milestone model as unique which cause only one user can have a milestone a day

* Add a safty guard at updateRecordStatus API to prevent milestone from not adding  when user uses the app the first time and records are not generated from API rather from adding directly